### PR TITLE
Improve terminology of buttons

### DIFF
--- a/cube_shuffle-wasm/src/components/app.rs
+++ b/cube_shuffle-wasm/src/components/app.rs
@@ -150,7 +150,7 @@ impl Component for App {
                 let delete_pile = link.callback(Msg::DelPile);
                 let update_seed = link.callback(Msg::UpdateSeed);
                 let update_pack_size = link.callback(Msg::UpdatePackSize);
-                let on_shuffle = link.callback(|_| Msg::Shuffle);
+                let to_shuffle = link.callback(|_| Msg::Shuffle);
                 let on_error = link.callback(|e| Msg::Error(Some(e)));
                 html! {
                     <>
@@ -180,7 +180,7 @@ impl Component for App {
                                 </div>
                                 <div class="field">
                                     <div class="control">
-                                        <button class="button is-success" onclick={ on_shuffle }>{ "Shuffle" }</button>
+                                        <button class="button is-success" onclick={ to_shuffle }>{ "Generate packs" }</button>
                                     </div>
                                 </div>
                             </div>
@@ -193,10 +193,10 @@ impl Component for App {
                 }
             }
             State::Shuffled { packs } => {
-                let re_pile = link.callback(|_| Msg::Pile);
+                let to_pile = link.callback(|_| Msg::Pile);
                 html! {
                     <>
-                        <button class="button is-danger" onclick={ re_pile }>{ "Re-pile" }</button>
+                        <button class="button is-danger" onclick={ to_pile }>{ "Back" }</button>
                         <PackList packs={ packs.clone() }/>
                     </>
                 }

--- a/docs/distribution_shuffle.adoc
+++ b/docs/distribution_shuffle.adoc
@@ -26,7 +26,7 @@ You may have as many piles as you wish, but all cards should belong to a pile.
 
 === Shuffle the piles
 
-Shuffle each pile individually without mixing them.
+Physically shuffle each pile individually without mixing them.
 Remember to keep track of which pile is which.
 
 === Register the piles
@@ -64,7 +64,7 @@ It would allow to defining groups for randomness mixing.
 
 === Pack content shuffle
 
-Let CubeShuffle shuffle and prepare your packs! Click the shuffle button for GUI or execute the CLI command. Below are the configurations available.
+Let CubeShuffle shuffle and prepare your packs! Click the `Generate packs` button for GUI or execute the CLI command. Below are the configurations available.
 
 ==== Seed
 
@@ -78,7 +78,7 @@ This is only expected to be the case with the same version of CubeShuffle.
 You will now be presented with a list of packs.
 This is a pack pick order list essentially.
 Each pack lists a number of cards from piles it should include.
-Thus to build each pack you just take as many cards from each pile as described.
+Thus, to build each pack you just take as many cards from each pile as described.
 In the GUI versions of CubeShuffle you can mark packs as picked.
 
 === Pack shuffle


### PR DESCRIPTION
Rename `Re-pile` button to `Back`.
Rename `Shuffle` to `Generate packs`.